### PR TITLE
Feature: waitFor and failAfter step configurations

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -94,6 +94,8 @@ export default class Run extends StepAwareCommand {
               stepText: step.map(s => s.stepText instanceof Array ? s.stepText[0] : s.stepText),
               client: step[0].client,
               registries: this.registry,
+              waitFor: step.map(s => s.waitFor[0]),
+              failAfter: step.map(s => s.failAfter[0]),
             })
             await this.runSteps(stepRunner, 2, true, false)
             timer.addPassedStep(step.length)

--- a/src/models/scenario.ts
+++ b/src/models/scenario.ts
@@ -81,6 +81,8 @@ export class Scenario {
       protoSteps: protoStep,
       stepText: step.step || stepDefName || stepDefExpression || stepDefId,
       registries: this.registries,
+      waitFor: step.waitFor || 0,
+      failAfter: step.failAfter || 0,
     })
   }
 

--- a/src/models/step.ts
+++ b/src/models/step.ts
@@ -97,10 +97,14 @@ export class Step {
                 if (this.shouldRetryStep(startedAt)) {
                   keepTrying(response)
                 } else {
-                  let originalResponse = response.getMessageFormat()
-                  originalResponse += ' (after %s)'
-                  response.setMessageFormat(originalResponse)
-                  response.addMessageArgs(Value.fromJavaScript(`${Math.ceil((Date.now() - startedAt) / 1000)}s`))
+                  // If configured to retry and we still failed, append helpful
+                  // error text indicating how long we tried before giving up.
+                  if (this.failAfter[0]) {
+                    let originalResponse = response.getMessageFormat()
+                    originalResponse += ' (after %s)'
+                    response.setMessageFormat(originalResponse)
+                    response.addMessageArgs(Value.fromJavaScript(`${Math.ceil((Date.now() - startedAt) / 1000)}s`))
+                  }
                   rejectResponse(response)
                   bail(new Error('Ran out of time before getting a satisfactory response.'))
                 }
@@ -149,10 +153,14 @@ export class Step {
                       keepTrying({})
                     } else {
                       hadFailure = true
-                      let originalResponse = data.getMessageFormat()
-                      originalResponse += ' (after %s)'
-                      data.setMessageFormat(originalResponse)
-                      data.addMessageArgs(Value.fromJavaScript(`${Math.ceil((Date.now() - startedAt) / 1000)}s`))
+                      // If configured to retry and we still failed, append helpful
+                      // error text indicating how long we tried before giving up.
+                      if (this.failAfter[stepNumber]) {
+                        let originalResponse = data.getMessageFormat()
+                        originalResponse += ' (after %s)'
+                        data.setMessageFormat(originalResponse)
+                        data.addMessageArgs(Value.fromJavaScript(`${Math.ceil((Date.now() - startedAt) / 1000)}s`))
+                      }
                       responses.push(data)
                       rejectResponse()
                       bail(new Error('Ran out of time before getting a satisfactory response.'))

--- a/src/models/step.ts
+++ b/src/models/step.ts
@@ -1,4 +1,6 @@
+import * as retry from 'async-retry'
 import {Promise as Bluebird} from 'bluebird'
+import {Value} from 'google-protobuf/google/protobuf/struct_pb'
 import * as grpc from 'grpc'
 
 import {AuthenticationError} from '../errors/authentication-error'
@@ -12,6 +14,8 @@ interface StepConstructorArgs {
   cog: string
   protoSteps: ProtoStep | ProtoStep[]
   stepText: string | string[]
+  waitFor?: number | number[]
+  failAfter?: number | number[]
   client?: CogServiceClient
   registries: Registries
 }
@@ -21,14 +25,18 @@ export class Step {
   public protoSteps: ProtoStep[]
   public stepText: string | string[]
   public client?: CogServiceClient
+  public waitFor: number[]
+  public failAfter: number[]
 
   private readonly auth: any = {}
 
-  constructor({cog, protoSteps, stepText, client, registries}: StepConstructorArgs) {
+  constructor({cog, protoSteps, stepText, client, registries, waitFor, failAfter}: StepConstructorArgs) {
     this.cog = cog
     this.protoSteps = protoSteps instanceof Array ? protoSteps : [protoSteps]
     this.stepText = stepText
     this.client = client
+    this.waitFor = waitFor && waitFor instanceof Array ? waitFor : [(waitFor || 0)]
+    this.failAfter = failAfter && failAfter instanceof Array ? failAfter : [(failAfter || 0)]
 
     const matchingReg = registries.buildCogRegistry().filter(a => a.name === cog)[0]
     const matchingAuth = registries.buildAuthRegistry().filter(a => a.cog === cog)
@@ -59,28 +67,55 @@ export class Step {
   }
 
   public async runStep(): Promise<RunStepResponse> {
+    // Wait before running this step, if configured.
+    await this.waitBeforeExecution()
+    const startedAt = Date.now()
+
     const request = new RunStepRequest()
     request.setStep(this.protoSteps[0])
     const meta = this.getAuthMeta()
 
-    return new Promise((resolve, reject) => {
-      if (!this.client) {
-        reject('No client initialized.')
-        return
+    // Well, this is getting quite unwieldy, isn't it?
+    return new Promise(async (returnResponse, rejectResponse) => {
+      try {
+        await retry(bail => {
+          return new Promise((doneTrying, keepTrying) => {
+            if (!this.client) {
+              bail(new Error('No client initialized.'))
+              return
+            }
+
+            this.client.runStep(request, meta, (err, response: RunStepResponse) => {
+              if (err) {
+                bail(err)
+                return
+              }
+
+              if (response.getOutcome() === RunStepResponse.Outcome.PASSED) {
+                doneTrying(returnResponse(response))
+              } else {
+                if (this.shouldRetryStep(startedAt)) {
+                  keepTrying(response)
+                } else {
+                  let originalResponse = response.getMessageFormat()
+                  originalResponse += ' (after %s)'
+                  response.setMessageFormat(originalResponse)
+                  response.addMessageArgs(Value.fromJavaScript(`${Math.ceil((Date.now() - startedAt) / 1000)}s`))
+                  rejectResponse(response)
+                  bail(new Error('Ran out of time before getting a satisfactory response.'))
+                }
+              }
+            })
+          })
+        }, {
+          retries: 1000,
+          factor: 1.25,
+          minTimeout: 5000,
+          maxTimeout: 120000,
+        })
+      } catch (e) {
+        // Error handled above. Catching here prevents an ugly stacktrace, etc.
       }
-
-      this.client.runStep(request, meta, (err, response: RunStepResponse) => {
-        if (err) {
-          reject(err)
-          return
-        }
-
-        if (response.getOutcome() === RunStepResponse.Outcome.PASSED) {
-          resolve(response)
-        } else {
-          reject(response)
-        }
-      })
     })
   }
 
@@ -95,23 +130,53 @@ export class Step {
     const meta = this.getAuthMeta()
     const stream: grpc.ClientDuplexStream<RunStepRequest, RunStepResponse> = this.client.runSteps(meta)
 
+    // Well, this is getting quite unwieldy, isn't it?
     try {
-      await Bluebird.mapSeries(this.protoSteps, protoStep => {
-        return new Promise((resolve, reject) => {
-          // Listen (only once) for data from the server.
-          stream.once('data', (data: RunStepResponse) => {
-            responses.push(data)
-            if (data.getOutcome() !== RunStepResponse.Outcome.PASSED) {
-              hadFailure = true
-              reject()
-            }
-            resolve()
-          })
+      await Bluebird.mapSeries(this.protoSteps, (protoStep, stepNumber) => {
+        return new Promise(async (returnResponse, rejectResponse) => {
+          try {
+            // Wait before executing this step (if configured)
+            await this.waitBeforeExecution(stepNumber)
+            const startedAt = Date.now()
 
-          // Write the step request onto the stream.
-          const request = new RunStepRequest()
-          request.setStep(protoStep)
-          stream.write(request)
+            await retry(bail => {
+              return new Promise((doneTrying, keepTrying) => {
+                // Listen (only once) for data from the server.
+                stream.once('data', (data: RunStepResponse) => {
+                  if (data.getOutcome() !== RunStepResponse.Outcome.PASSED) {
+                    if (this.shouldRetryStep(startedAt, stepNumber)) {
+                      // Have to pass an empty object due to bug in async-retry...
+                      keepTrying({})
+                    } else {
+                      hadFailure = true
+                      let originalResponse = data.getMessageFormat()
+                      originalResponse += ' (after %s)'
+                      data.setMessageFormat(originalResponse)
+                      data.addMessageArgs(Value.fromJavaScript(`${Math.ceil((Date.now() - startedAt) / 1000)}s`))
+                      responses.push(data)
+                      rejectResponse()
+                      bail(new Error('Ran out of time before getting a satisfactory response.'))
+                    }
+                  } else {
+                    responses.push(data)
+                    doneTrying(returnResponse())
+                  }
+                })
+
+                // Write the step request onto the stream.
+                const request = new RunStepRequest()
+                request.setStep(protoStep)
+                stream.write(request)
+              })
+            }, {
+              retries: 1000,
+              factor: 1.25,
+              minTimeout: 5000,
+              maxTimeout: 120000,
+            })
+          } catch (e) {
+            // Error handled above. Catching here prevents an ugly stacktrace, etc.
+          }
         })
       })
     } catch (e) {}
@@ -122,6 +187,29 @@ export class Step {
         hadFailure ? reject(responses) : resolve(responses)
       })
     })
+  }
+
+  protected async waitBeforeExecution(stepNumber = 0) {
+    if (this.waitFor[stepNumber] <= 0) {
+      return
+    }
+
+    return new Promise((resolve: () => void) => {
+      setTimeout(resolve, this.waitFor[stepNumber] * 1000)
+    })
+  }
+
+  /**
+   * Returns whether or not the step should be retried.
+   *
+   * @param startedAt - The timestamp (ms) when the step started executing.
+   *
+   * @param stepNumber - If this step represents an optimized set of multiple
+   *   steps, then this number represents the zero-index'd step number whose
+   *   failAfter setting should be checked.
+   */
+  protected shouldRetryStep(startedAt: number, stepNumber = 0): boolean {
+    return Date.now() - startedAt < (this.failAfter[stepNumber] * 1000)
   }
 
   private getAuthMeta() {


### PR DESCRIPTION
## What / Why
In order to reduce the likelihood of a proliferation of `WaitForX` steps in Cogs, we should introduce a simple retry concept that can be manipulated in configuration.

## API Additions:
- Crank now respects`waitFor` key on `step` objects in scenario yaml files. A step will not be executed until as many seconds as is set on `waitFor`. When not provided, a default value of 0 is assumed.
- Crank now respects `failAfter` key on `step` objects in scenario yaml files. When set, a step will be retried for up to as many seconds before returning with a `fail`/`error` outcome. When not provided, a default value of 0 is assumed.