### PR TITLE
Initial support for tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6010,6 +6010,11 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "token-substitute": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/token-substitute/-/token-substitute-1.2.0.tgz",
+      "integrity": "sha1-3Q792a7G2VEgS0hfsxiNXe5f5qo="
+    },
     "treeify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "inquirer": "^6.3.1",
     "node-forge": "^0.8.4",
     "rxjs": "^6.5.2",
+    "token-substitute": "^1.2.0",
     "tslib": "^1.10.0",
     "yaml": "^1.6.0",
     "yeoman-environment": "^2.3.4",


### PR DESCRIPTION
## What / Why
In order to reduce the fragility of test scenarios, (and eventually introduce more complex/emergent scenarios), we should introduce a token mechanism and syntax, allowing commonly used variables to be defined at the top of a scenario, and used throughout steps.

## API Additions
- Crank is now aware of the `tokens` key at the top level of a scenario file; this represents an object of token names/values that may be substituted into steps (whether in step text or step data) before they are executed.
- The `crank run` command now accepts `--token` or `-t` flags, which allow tokens to be provided / overridden at runtime.

## Examples
```yml
# example-scenario.yml
scenario: Token Demonstration
description: Contrived example demonstrating tokens in scenario files.

tokens:
  testEmail: atommy@example.com
  utmMedium: Email

steps:
- step: When I navigate to http://example.com/lp.html?utm_medium={{utmMedium}}
- step: And I fill out input[name="Email"] with {{testEmail}}
- step: And I submit the form by clicking button[type="submit"]
- step: Then the utm_medium__c field on marketo lead {{testEmail}} should be {{utmMedium}}
```

The above could also be overridden at runtime as follows:

```shell-session
$ crank run example-scenario.yml --token utmMedium=Social
```