### PR TITLE
Better support optional fields on steps

### DIFF
--- a/src/assets/templates/typescript/src/core/base-step.ts
+++ b/src/assets/templates/typescript/src/core/base-step.ts
@@ -11,6 +11,7 @@ export interface Field {
   field: string;
   type: FieldDefinition.Type;
   description: string;
+  optionality?: number;
 }
 
 export abstract class BaseStep {
@@ -37,9 +38,14 @@ export abstract class BaseStep {
       const expectedField = new FieldDefinition();
       expectedField.setType(field.type);
       expectedField.setKey(field.field);
-      expectedField.setOptionality(FieldDefinition.Optionality.REQUIRED);
       expectedField.setDescription(field.description);
       stepDefinition.addExpectedFields(expectedField);
+
+      if (field.hasOwnProperty('optionality')) {
+        expectedField.setOptionality(field.optionality);
+      } else {
+        expectedField.setOptionality(FieldDefinition.Optionality.REQUIRED);
+      }
     });
 
     return stepDefinition;

--- a/src/models/scenario.ts
+++ b/src/models/scenario.ts
@@ -67,6 +67,13 @@ export class Scenario {
 
           if (matches.hasOwnProperty('groups')) {
             data = Object.assign(data, matches.groups)
+
+            // Allow for optional fields.
+            Object.keys(data).forEach((dataKey) => {
+              if (typeof data[dataKey] === 'undefined') {
+                delete data[dataKey]
+              }
+            });
           }
 
           protoStep.setData(Struct.fromJavaScript(data))

--- a/src/models/scenario.ts
+++ b/src/models/scenario.ts
@@ -69,11 +69,11 @@ export class Scenario {
             data = Object.assign(data, matches.groups)
 
             // Allow for optional fields.
-            Object.keys(data).forEach((dataKey) => {
-              if (typeof data[dataKey] === 'undefined') {
+            Object.keys(data).forEach(dataKey => {
+              if (data[dataKey] === 'undefined') {
                 delete data[dataKey]
               }
-            });
+            })
           }
 
           protoStep.setData(Struct.fromJavaScript(data))

--- a/src/step-aware-command.ts
+++ b/src/step-aware-command.ts
@@ -91,7 +91,9 @@ export default abstract class extends RegistryAwareCommand {
 
     if (printMessage || !passed) {
       const formatArgs: any = stepResponse.getMessageArgsList().map((value: Value) => {
-        return value.toJavaScript()
+        // If the value is null, replace with empty string.
+        const jsValue = value.toJavaScript();
+        return jsValue === null ? '' : jsValue
       })
       formatArgs.unshift(stepResponse.getMessageFormat())
       const resultMessage: string = util.format.apply(util, formatArgs)

--- a/src/step-aware-command.ts
+++ b/src/step-aware-command.ts
@@ -92,7 +92,7 @@ export default abstract class extends RegistryAwareCommand {
     if (printMessage || !passed) {
       const formatArgs: any = stepResponse.getMessageArgsList().map((value: Value) => {
         // If the value is null, replace with empty string.
-        const jsValue = value.toJavaScript();
+        const jsValue = value.toJavaScript()
         return jsValue === null ? '' : jsValue
       })
       formatArgs.unshift(stepResponse.getMessageFormat())


### PR DESCRIPTION
- Fixes a bug related to running steps with optional fields.
- Improves message output when `null` values are provided as arguments for response messages.
- Improves scaffolded code to allow for setting `optionality` on step instances extending the base step.

Closes #7 