### PR TITLE
Feature: support non-interactive auth via env variables

### DIFF
--- a/src/commands/cog/install.ts
+++ b/src/commands/cog/install.ts
@@ -115,14 +115,25 @@ export default class Install extends RegistryAwareCommand {
         return
       }
 
-      this.log('Please provide authentication details required by the cog:')
-      const authFields = await Bluebird.mapSeries(cogRegEntry.authFieldsList, async (authField): Promise<inquirer.Answer> => {
-        return inquirer.prompt({
-          name: authField.key,
-          message: authField.description || authField.key,
-          type: 'password'
-        })
+      // Check environment for supplied authentication details in the form of
+      // CRANK_COG_NAME__AUTHFIELDKEY (all caps, where non-alphanum chars are
+      // replaced with underscores).
+      const envPrefix = `crank_${cogRegEntry.name}`.replace(/[^a-zA-Z0-9]+/g, '_')
+      let authFields: any = cogRegEntry.authFieldsList.map(field => {
+        const key = `${envPrefix}__${field.key.replace(/[^a-zA-Z0-9]+/g, '_')}`.toUpperCase()
+        return process.env[key] ? {[field.key]: process.env[key]} : undefined
       })
+
+      if (authFields.filter((a: any) => a === undefined).length) {
+        this.log('Please provide authentication details required by the cog:')
+        authFields = await Bluebird.mapSeries(cogRegEntry.authFieldsList, async (authField): Promise<inquirer.Answer> => {
+          return inquirer.prompt({
+            name: authField.key,
+            message: authField.description || authField.key,
+            type: 'password'
+          })
+        })
+      }
 
       this.logDebug('Installing Cog %s authentication details', args.cogName)
       await this.installCogAuth(cogName, authFields)

--- a/src/commands/cog/readme.ts
+++ b/src/commands/cog/readme.ts
@@ -117,6 +117,10 @@ The readme must have any of the following tags inside of it for it to be replace
   }
 
   authFieldsAsMarkdown(authField: Record<string, any>): string {
-    return `- **${authField.key}**: ${authField.description}`
+    const {args} = this.parse(ReadMe)
+    const envPrefix = `crank_${args.cogName}`.replace(/[^a-zA-Z0-9]+/g, '_')
+    const key = `${envPrefix}__${authField.key.replace(/[^a-zA-Z0-9]+/g, '_')}`.toUpperCase()
+    return `- **${authField.key}**: ${authField.description}
+  - Set via environment variable \`${key}\``
   }
 }


### PR DESCRIPTION
- Allows `crank cog:install [cog/name]` and `crank cog:auth [cog/name]` to skip prompting authentication credentials if environment variables of the expected name are provided.
- Updates `crank cog:readme` to include the environment variable name in authentication details section.

Closes #11 