### PR TITLE
Properly hide (but provide feedback on) sensitive auth fields

### DIFF
--- a/src/commands/cog/auth.ts
+++ b/src/commands/cog/auth.ts
@@ -53,12 +53,19 @@ export class Auth extends RegistryAwareCommand {
         return inquirer.prompt({
           name: authField.key,
           message: authField.description || authField.key,
+          type: this.authFieldMayBeSensitive(authField.key) ? 'password' : 'input',
+          mask: this.authFieldMayBeSensitive(authField.key) ? '*' : undefined
         })
       })
     }
 
     await this.installCogAuth(args.cogName, authFields)
     this.log(`Successfully updated authentication details for ${args.cogName}`)
+  }
+
+  protected authFieldMayBeSensitive(key: string): boolean {
+    const lkey = key.toLowerCase()
+    return lkey.includes('key') || lkey.includes('pass') || lkey.includes('secret')
   }
 
 }

--- a/src/commands/cog/install.ts
+++ b/src/commands/cog/install.ts
@@ -130,7 +130,8 @@ export default class Install extends RegistryAwareCommand {
           return inquirer.prompt({
             name: authField.key,
             message: authField.description || authField.key,
-            type: 'password'
+            type: this.authFieldMayBeSensitive(authField.key) ? 'password' : 'input',
+            mask: this.authFieldMayBeSensitive(authField.key) ? '*' : undefined
           })
         })
       }
@@ -192,6 +193,10 @@ export default class Install extends RegistryAwareCommand {
           .catch(reject)
       })
     })
+  }
+
+  protected authFieldMayBeSensitive(key: string): boolean {
+    return key.includes('key') || key.includes('pass') || key.includes('secret')
   }
 
 }


### PR DESCRIPTION
Adds mask to password fields to provide feedback on what has been filled out.  Removes password/mask from auth fields which are less sensitive.
#15 #16 