### PR TITLE
Run all consecutive validation steps, regardless of outcome

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -174,7 +174,6 @@ export default class Run extends StepAwareCommand {
             }
             process.exitCode = 1
 
-            // @todo: Also need to check that the fail was (or the last fail was) on a validation step.
             // If the next step/series of steps is or begins with a validation,
             // then resolve and let the next step be executed.
             if (scenario.optimizedSteps[index + 1]) {


### PR DESCRIPTION
Fixes #37.

With this PR, we will automatically run all consecutive `validation` steps, regardless of their individual outcomes, until either an `action` step is encountered, or the end of the scenario is encountered.

This new behavior will not affect the outcome of any scenario: if any step results in a `fail` or `error`, the scenario as a whole will still reflect that.  It merely improves situations where a user may want to know _all_ associated failures without having to repeatedly run a test, find problems, and fix them.