### PR TITLE
Feature: Pass Scoped IDs on Run Step Requests to Cogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -585,6 +585,12 @@
         "@types/node": "*"
       }
     },
+    "@types/uuid": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.7.tgz",
+      "integrity": "sha512-C2j2FWgQkF1ru12SjZJyMaTPxs/f6n90+5G5qNakBxKXjTBc/YTSelHh4Pz1HUDwxFXD9WvpQhOGCDC+/Y4mIQ==",
+      "dev": true
+    },
     "@types/vinyl": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.3.tgz",
@@ -1077,6 +1083,14 @@
         "url": "0.10.3",
         "uuid": "3.3.2",
         "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
+        }
       }
     },
     "balanced-match": {
@@ -6369,10 +6383,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "rxjs": "^6.5.2",
     "token-substitute": "^1.2.0",
     "tslib": "^1.10.0",
+    "uuid": "^3.4.0",
     "yaml": "^1.6.0",
     "yeoman-environment": "^2.3.4",
     "yeoman-generator": "^4.0.1"
@@ -49,6 +50,7 @@
     "@types/node-forge": "^0.8.3",
     "@types/protobufjs": "^5.0.31",
     "@types/rimraf": "^2.0.2",
+    "@types/uuid": "^3.4.7",
     "@types/yaml": "^1.0.2",
     "@types/yeoman-environment": "^2.3.1",
     "aws-sdk": "^2.488.0",

--- a/src/assets/proto/README.md
+++ b/src/assets/proto/README.md
@@ -117,6 +117,9 @@ request to your Cog to run a step.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | step | [Step](#automaton.cog.Step) |  | The step your Cog should run, identified by `step_id`, and including data as specified in your corresponding `StepDefinition`. |
+| request_id | [string](#string) |  | Represents a string identifier that your Cog or step execution code can use to help understand the context of a request or as part of a cache key. <br><br> For steps run via the `RunStep` (unary) method, this value will be different for every step. For steps run via the `RunSteps` (streaming) method, this value will be the same across all step requests for a single stream. |
+| scenario_id | [string](#string) |  | Represents a string identifier that your Cog or step execution code can use to help understand the context of a request or as part of a cache key. <br><br> This value will be the same for every step on a single scenario run, but will differ across scenarios when run in the same session (e.g. when a folder of scenarios is run). If the same scenario is run twice, but via separate run invocations, this ID will be different for each run. |
+| requestor_id | [string](#string) |  | Represents a string identifier that your Cog or step execution code can use to help understand the context of a request or as part of a cache key. <br><br> This value will be the same for every step on every scenario run by a given requestor. This value will be the same, even between separate run invocations. |
 
 
 

--- a/src/assets/proto/cog.proto
+++ b/src/assets/proto/cog.proto
@@ -326,6 +326,38 @@ message RunStepRequest {
    */
   Step step = 1;
 
+  /**
+   * Represents a string identifier that your Cog or step execution code can
+   * use to help understand the context of a request or as part of a cache key.
+   * <br><br>
+   * For steps run via the `RunStep` (unary) method, this value will be
+   * different for every step. For steps run via the `RunSteps` (streaming)
+   * method, this value will be the same across all step requests for a single
+   * stream.
+   */
+  string request_id = 2;
+
+  /**
+   * Represents a string identifier that your Cog or step execution code can
+   * use to help understand the context of a request or as part of a cache key.
+   * <br><br>
+   * This value will be the same for every step on a single scenario run, but
+   * will differ across scenarios when run in the same session (e.g. when a
+   * folder of scenarios is run). If the same scenario is run twice, but via
+   * separate run invocations, this ID will be different for each run.
+   */
+  string scenario_id = 3;
+
+  /**
+   * Represents a string identifier that your Cog or step execution code can
+   * use to help understand the context of a request or as part of a cache key.
+   * <br><br>
+   * This value will be the same for every step on every scenario run by a
+   * given requestor. This value will be the same, even between separate run
+   * invocations.
+   */
+  string requestor_id = 4;
+
 }
 
 /**

--- a/src/commands/cog/step.ts
+++ b/src/commands/cog/step.ts
@@ -3,6 +3,7 @@ import {flags} from '@oclif/parser'
 import cli from 'cli-ux'
 import * as debug from 'debug'
 import * as inquirer from 'inquirer'
+import * as uuidv4 from 'uuid/v4'
 
 import {Step as StepRunner} from '../../models/step'
 import {CogServiceClient} from '../../proto/cog_grpc_pb'
@@ -94,7 +95,8 @@ export default class Step extends StepAwareCommand {
       stepText: '',
       client: cogClient,
       registries: this.registry,
-      protoSteps: [protoStep]
+      protoSteps: [protoStep],
+      scenarioId: uuidv4(),
     })
 
     this.log()

--- a/src/commands/cog/steps.ts
+++ b/src/commands/cog/steps.ts
@@ -5,6 +5,7 @@ import cli from 'cli-ux'
 import * as debug from 'debug'
 import * as inquirer from 'inquirer'
 import {Subject} from 'rxjs'
+import * as uuidv4 from 'uuid/v4'
 
 import {Step as StepRunner} from '../../models/step'
 import {CogServiceClient} from '../../proto/cog_grpc_pb'
@@ -106,7 +107,8 @@ export default class Step extends StepAwareCommand {
       stepText: '',
       client: cogClient,
       registries: this.registry,
-      protoSteps: steps
+      protoSteps: steps,
+      scenarioId: uuidv4(),
     })
 
     this.log('\nAd-hoc scenario\n')

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,6 +7,7 @@ import * as debug from 'debug'
 import * as fs from 'fs'
 import * as glob from 'glob'
 import * as _ from 'lodash'
+import * as uuidv4 from 'uuid/v4'
 
 import {AuthenticationError} from '../errors/authentication-error'
 import {MissingStepError} from '../errors/missing-step-error'
@@ -109,6 +110,7 @@ export default class Run extends StepAwareCommand {
     // Run through scenarios.
     const overallTimer = new Timer()
     await Bluebird.mapSeries(scenarios, async (scenario: Scenario) => {
+      const scenarioID = uuidv4()
       let hasFailures = false
 
       // Run through steps.
@@ -128,6 +130,7 @@ export default class Run extends StepAwareCommand {
                 waitFor: step.map(s => s.waitFor[0]),
                 failAfter: step.map(s => s.failAfter[0]),
                 priorFailure: hasFailures,
+                scenarioId: scenarioID,
               })
               await this.runSteps(stepRunner, 2, true, false)
               timer.addPassedStep(step.length)

--- a/src/proto/cog_pb.d.ts
+++ b/src/proto/cog_pb.d.ts
@@ -186,6 +186,15 @@ export class RunStepRequest extends jspb.Message {
     getStep(): Step | undefined;
     setStep(value?: Step): void;
 
+    getRequestId(): string;
+    setRequestId(value: string): void;
+
+    getScenarioId(): string;
+    setScenarioId(value: string): void;
+
+    getRequestorId(): string;
+    setRequestorId(value: string): void;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): RunStepRequest.AsObject;
@@ -200,6 +209,9 @@ export class RunStepRequest extends jspb.Message {
 export namespace RunStepRequest {
     export type AsObject = {
         step?: Step.AsObject,
+        requestId: string,
+        scenarioId: string,
+        requestorId: string,
     }
 }
 

--- a/src/proto/cog_pb.js
+++ b/src/proto/cog_pb.js
@@ -1122,7 +1122,10 @@ proto.automaton.cog.RunStepRequest.prototype.toObject = function(opt_includeInst
  */
 proto.automaton.cog.RunStepRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    step: (f = msg.getStep()) && proto.automaton.cog.Step.toObject(includeInstance, f)
+    step: (f = msg.getStep()) && proto.automaton.cog.Step.toObject(includeInstance, f),
+    requestId: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    scenarioId: jspb.Message.getFieldWithDefault(msg, 3, ""),
+    requestorId: jspb.Message.getFieldWithDefault(msg, 4, "")
   };
 
   if (includeInstance) {
@@ -1164,6 +1167,18 @@ proto.automaton.cog.RunStepRequest.deserializeBinaryFromReader = function(msg, r
       reader.readMessage(value,proto.automaton.cog.Step.deserializeBinaryFromReader);
       msg.setStep(value);
       break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setRequestId(value);
+      break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setScenarioId(value);
+      break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setRequestorId(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -1201,6 +1216,27 @@ proto.automaton.cog.RunStepRequest.serializeBinaryToWriter = function(message, w
       proto.automaton.cog.Step.serializeBinaryToWriter
     );
   }
+  f = message.getRequestId();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getScenarioId();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
+  f = message.getRequestorId();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
+      f
+    );
+  }
 };
 
 
@@ -1231,6 +1267,51 @@ proto.automaton.cog.RunStepRequest.prototype.clearStep = function() {
  */
 proto.automaton.cog.RunStepRequest.prototype.hasStep = function() {
   return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional string request_id = 2;
+ * @return {string}
+ */
+proto.automaton.cog.RunStepRequest.prototype.getRequestId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/** @param {string} value */
+proto.automaton.cog.RunStepRequest.prototype.setRequestId = function(value) {
+  jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional string scenario_id = 3;
+ * @return {string}
+ */
+proto.automaton.cog.RunStepRequest.prototype.getScenarioId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.automaton.cog.RunStepRequest.prototype.setScenarioId = function(value) {
+  jspb.Message.setProto3StringField(this, 3, value);
+};
+
+
+/**
+ * optional string requestor_id = 4;
+ * @return {string}
+ */
+proto.automaton.cog.RunStepRequest.prototype.getRequestorId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/** @param {string} value */
+proto.automaton.cog.RunStepRequest.prototype.setRequestorId = function(value) {
+  jspb.Message.setProto3StringField(this, 4, value);
 };
 
 

--- a/src/services/registries.ts
+++ b/src/services/registries.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
+import * as uuidv5 from 'uuid/v5'
 
 import {CogConfig} from './cog-manager'
 
@@ -189,6 +190,10 @@ export class Registries {
 
     this.authRegistry = registry
     fs.writeFileSync(path.join(this.cacheDir, 'default-profile.json'), JSON.stringify(registry))
+  }
+
+  public getRegistryRequestorId(): string {
+    return uuidv5(JSON.stringify(this.buildAuthRegistry()), 'bc2bd6f5-5f99-4433-a24e-7fdf52c15917')
   }
 
 }


### PR DESCRIPTION
## What / Why
With this update, we'll be passing three IDs on `RunStepRequest` messages sent to Cogs.  They are:
- `request_id`: Scoped to an individual request to a Cog (e.g. will be unique to each unary `RunStep` call or the same across multiple steps on a single streaming `RunSteps` call).
- `scenario_id`: Scoped to an individual scenario run (e.g. will be the same for all steps in a single `crank run` invocation)
- `requestor_id`: Scoped to the individual making the request (e.g. will be the same for all scenarios and all steps across multiple, disparate invocations)

These IDs can be used in Cog / step execution code in order to cache network requests to source systems.  These IDs can be used to mitigate API call limits in a couple of scenarios:
- **Metadata Requests**: some steps may need to make requests about object or field definitions which would not reasonably change within a single scenario. When steps like these are commonly repeated, it makes sense to temporarily cache that metadata.
- **Data Requests**: it's common to chain object check steps together. In situations like this, it doesn't make sense to repeatedly query for the same object over and over: it can be loaded once and cached for the duration of the request.