### PR TITLE
Introduce the concept of dynamic tokens

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -121,6 +121,7 @@ export default class Run extends StepAwareCommand {
             if (step instanceof Array) {
               const stepRunner = new RunnerStep({
                 cog: step[0].cog,
+                tokens: scenario.tokens,
                 protoSteps: step.map(s => s.protoSteps instanceof Array ? s.protoSteps[0] : s.protoSteps),
                 stepText: step.map(s => s.stepText instanceof Array ? s.stepText[0] : s.stepText),
                 client: step[0].client,

--- a/src/models/scenario.ts
+++ b/src/models/scenario.ts
@@ -24,6 +24,7 @@ export class Scenario {
   public readonly id: string
   public name: string
   public description: string
+  public tokens: Record<string, any>
   public steps: RunnerStep[]
   public optimizedSteps: (RunnerStep | RunnerStep[])[]
   public file: string
@@ -36,8 +37,8 @@ export class Scenario {
     this.id = uuidv4()
 
     const scenario = YAML.parse(fs.readFileSync(fromFile).toString('utf8'))
-    const combinedTokens = Object.assign({}, (scenario.tokens || {}), tokenOverrides)
-    let rawSteps = this.applyTokens(scenario.steps, combinedTokens)
+    this.tokens = Object.assign({}, (scenario.tokens || {}), tokenOverrides)
+    let rawSteps = this.applyTokens(scenario.steps, this.tokens)
     this.name = scenario.scenario
     this.description = scenario.description
     this.steps = rawSteps.map((step: any) => {
@@ -96,6 +97,7 @@ export class Scenario {
 
     return new RunnerStep({
       cog: cogName,
+      tokens: this.tokens,
       protoSteps: protoStep,
       stepText: step.step || stepDefName || stepDefExpression || stepDefId,
       registries: this.registries,

--- a/src/models/step.ts
+++ b/src/models/step.ts
@@ -333,7 +333,7 @@ export class Step {
           table.getRowsList().forEach((row, index) => {
             const rowData = row.toJavaScript()
             Object.keys(rowData).forEach(key => {
-              this.tokens[`${keyPrefix}.${index}.${key}`.toLowerCase()] = rowData[key]
+              this.tokens[`${keyPrefix}.${index + 1}.${key}`.toLowerCase()] = rowData[key]
             })
           })
         }

--- a/src/models/step.ts
+++ b/src/models/step.ts
@@ -1,15 +1,18 @@
 import * as retry from 'async-retry'
 import {Promise as Bluebird} from 'bluebird'
-import {Value} from 'google-protobuf/google/protobuf/struct_pb'
+import {Struct, Value} from 'google-protobuf/google/protobuf/struct_pb'
 import * as grpc from 'grpc'
 import * as uuidv4 from 'uuid/v4'
 
 import {AuthenticationError} from '../errors/authentication-error'
 import {CogServiceClient} from '../proto/cog_grpc_pb'
-import {RunStepRequest, RunStepResponse, Step as ProtoStep, StepDefinition} from '../proto/cog_pb'
+import {RunStepRequest, RunStepResponse, Step as ProtoStep, StepDefinition, StepRecord} from '../proto/cog_pb'
 import {CogRegistryEntry, Registries, StepRegistryEntry} from '../services/registries'
 
+const substitute = require('token-substitute')
+
 /* tslint:disable:no-unused */
+/* tslint:disable:no-console */
 
 interface StepConstructorArgs {
   cog: string
@@ -21,6 +24,7 @@ interface StepConstructorArgs {
   scenarioId: string
   client?: CogServiceClient
   registries: Registries
+  tokens?: Record<string, any>
 }
 
 export class Step {
@@ -32,13 +36,15 @@ export class Step {
   public failAfter: number[]
   public priorFailure: boolean
 
+  protected tokens: Record<string, any>
+
   private readonly auth: any = {}
   private readonly reg: CogRegistryEntry
   private readonly requestId: string
   private readonly scenarioId: string
   private readonly requestorId: string
 
-  constructor({cog, protoSteps, stepText, client, registries, waitFor, failAfter, scenarioId, priorFailure = false}: StepConstructorArgs) {
+  constructor({cog, protoSteps, stepText, client, registries, waitFor, failAfter, scenarioId, tokens = {}, priorFailure = false}: StepConstructorArgs) {
     this.cog = cog
     this.protoSteps = protoSteps instanceof Array ? protoSteps : [protoSteps]
     this.stepText = stepText
@@ -49,6 +55,7 @@ export class Step {
     this.requestId = uuidv4()
     this.scenarioId = scenarioId
     this.requestorId = registries.getRegistryRequestorId()
+    this.tokens = tokens
 
     const matchingReg = registries.buildCogRegistry().filter(a => a.name === cog)[0]
     const matchingAuth = registries.buildAuthRegistry().filter(a => a.cog === cog)
@@ -84,6 +91,9 @@ export class Step {
     await this.waitBeforeExecution()
     const startedAt = Date.now()
 
+    // Apply any new dynamic token data to the step.
+    this.applyTokens(this.protoSteps[0])
+
     const request = new RunStepRequest()
     request.setStep(this.protoSteps[0])
     request.setRequestId(this.requestId)
@@ -106,6 +116,9 @@ export class Step {
                 bail(err)
                 return
               }
+
+              // Merge response data into tokens.
+              this.mergeResponseTokens(response)
 
               if (response.getOutcome() === RunStepResponse.Outcome.PASSED) {
                 doneTrying(returnResponse(response))
@@ -163,6 +176,9 @@ export class Step {
               return new Promise((doneTrying, keepTrying) => {
                 // Listen (only once) for data from the server.
                 stream.once('data', (data: RunStepResponse) => {
+                  // Merge response data into tokens.
+                  this.mergeResponseTokens(data)
+
                   if (data.getOutcome() !== RunStepResponse.Outcome.PASSED) {
                     if (this.shouldRetryStep(startedAt, stepNumber)) {
                       // Have to pass an empty object due to bug in async-retry...
@@ -202,6 +218,9 @@ export class Step {
                     }
                   }
                 })
+
+                // Apply any new dynamic token data to the step.
+                this.applyTokens(protoStep)
 
                 // Write the step request onto the stream.
                 const request = new RunStepRequest()
@@ -268,6 +287,58 @@ export class Step {
    */
   protected shouldRetryStep(startedAt: number, stepNumber = 0): boolean {
     return Date.now() - startedAt < (this.failAfter[stepNumber] * 1000)
+  }
+
+  protected applyTokens(protoStep: ProtoStep) {
+    try {
+      // Pull data from the step protobuf message.
+      const data = protoStep.getData() || null
+
+      if (data) {
+        // Apply currently known/dynamic tokens to the step data.
+        const newData = substitute(data.toJavaScript(), {
+          tokens: this.tokens,
+          prefix: '{{',
+          suffix: '}}',
+          preserveUnknownTokens: true,
+        })
+
+        // Re-set the step data on the protobuf step message.
+        protoStep.setData(Struct.fromJavaScript(newData))
+      }
+      // tslint:disable-next-line:no-unused
+    } catch (e) {
+      console.error('Error substituting token values, but continuing. Check your tokens')
+    }
+  }
+
+  protected mergeResponseTokens(response: RunStepResponse) {
+    const cog = this.cog.split('/')[1]
+    response.getRecordsList().forEach(record => {
+      const keyPrefix = `${cog}.${record.getId()}`
+
+      if (record.getValueCase() === StepRecord.ValueCase.KEY_VALUE) {
+        const keyValue = record.getKeyValue()
+        if (keyValue) {
+          const keyValueData = keyValue.toJavaScript()
+          Object.keys(keyValueData).forEach(key => {
+            this.tokens[`${keyPrefix}.${key}`.toLowerCase()] = keyValueData[key]
+          })
+        }
+      }
+
+      if (record.getValueCase() === StepRecord.ValueCase.TABLE) {
+        const table = record.getTable()
+        if (table) {
+          table.getRowsList().forEach((row, index) => {
+            const rowData = row.toJavaScript()
+            Object.keys(rowData).forEach(key => {
+              this.tokens[`${keyPrefix}.${index}.${key}`.toLowerCase()] = rowData[key]
+            })
+          })
+        }
+      }
+    })
   }
 
   private getAuthMeta() {

--- a/src/models/step.ts
+++ b/src/models/step.ts
@@ -303,6 +303,16 @@ export class Step {
           preserveUnknownTokens: true,
         })
 
+        // Also apply currently known/dynamic tokens to the step text.
+        if (this.stepText) {
+          this.stepText = substitute(this.stepText, {
+            tokens: this.tokens,
+            prefix: '{{',
+            suffix: '}}',
+            preserveUnknownTokens: true,
+          })
+        }
+
         // Re-set the step data on the protobuf step message.
         protoStep.setData(Struct.fromJavaScript(newData))
       }

--- a/src/models/step.ts
+++ b/src/models/step.ts
@@ -332,7 +332,7 @@ export class Step {
         if (keyValue) {
           const keyValueData = keyValue.toJavaScript()
           Object.keys(keyValueData).forEach(key => {
-            this.tokens[`${keyPrefix}.${key}`.toLowerCase()] = keyValueData[key]
+            this.tokens[`${keyPrefix}.${key}`] = keyValueData[key]
           })
         }
       }
@@ -343,7 +343,7 @@ export class Step {
           table.getRowsList().forEach((row, index) => {
             const rowData = row.toJavaScript()
             Object.keys(rowData).forEach(key => {
-              this.tokens[`${keyPrefix}.${index + 1}.${key}`.toLowerCase()] = rowData[key]
+              this.tokens[`${keyPrefix}.${index + 1}.${key}`] = rowData[key]
             })
           })
         }


### PR DESCRIPTION
## What / Why
This PR introduces support for **Dynamic Tokens**, which allow scenarios to be written with assertions and actions that depend on data that is only known at run-time.  The full details on the spec can be found in #43.  It builds off the work in #41 to allow Cogs to expose structured data.

## Example Use-Cases:

**Salesforce Object Assignment and Reference Precision**
```yml
scenario: Salesforce Account Assign
description: Proves...

tokens:
  test.account: A Test Account
  test.email: 46426f22-af1c-4f52-978e-9616002c24a6@thisisjust.atomatest.com

steps:
# This step exposes the ID of the created Account as a token.
- step: Given I create a Salesforce Account
  data:
    account:
      Name: '{{test.account}}'
- step: And I create a Salesforce Contact
  data:
    contact:
      Email: '{{test.email}}'
      LastName: Tommy
      # Note: The ID can be used to assign the contact to the account. 
      AccountId: '{{salesforce.account.Id}}'
# The ID can be used to precisely target the object for field comparison
- step: Then the Name field on Salesforce Account with Id {{salesforce.account.Id}} should be {{test.account}}
- step: And the AccountId field on Salesforce Contact {{test.email}} should be {{salesforce.account.Id}}
- step: Finally, delete the {{test.email}} Salesforce Contact
# And it can be used to precisely target the object for deletion (no more ambiguity)
- step: And delete the Salesforce Account with Id {{salesforce.account.Id}}
```

**Google Analytics Advanced Use-Cases**
```yml
scenario: GA CID on Custom Dimension
description: |
  Proves that the Google Analytics CID can be used as a dynamic token.

steps:
- step: When I navigate to https://www.tableau.com/products/trial
# This step exposes the GA Client ID as a token.
- step: Then Google Analytics should have tracked a pageview for tracking id UA-625217-46
- step: When I click the page element [href="/academic/students#form"]
- step: Then Google Analytics should have tracked an event with category form and action form present for tracking id UA-625217-46
  data:
    withParameters:
      # Which can be used here to validate custom dimension logic.
      cd52: '{{web.googleAnalyticsRequest.cid}}'
```

**Simulating Clicks in Email Links**
```yml
scenario: Email Link "Click"
description: |
  Proves that it's possible to simulate a link click from an email.

tokens:
  test.email: 56426f22-af1c-4f52-978e-9616002c24a6@thisisjust.atomatest.com

steps:
- step: Given I navigate to http://go.automatoninc.com/Dev-QA-Email-Confirmation.html
- step: And I fill out [name=FirstName] with Atoma
- step: And I fill out [name=LastName] with Tommy
- step: And I fill out [name=Email] with {{test.email}}
- step: "And I submit the form by clicking #mktoForm_1105 button[type=submit]"
# This step exposes a list of links in the email (which are wrapped in a click-tracking domain)
- step: Then the 1st mailgun email for {{test.email}} should not contain broken links
  failAfter: 120
# Which can be used to simulate a link click.
- step: When I navigate to {{inbox-mailgun.links.1.Url}}
- step: Then the title meta tag on the current page should be Example Domain
- step: Finally, delete the {{test.email}} marketo lead
```

Closes #43.
<!--

Old Todo items from during implementation:

### Todo
- [x] Token replacement needs to be added to step text (e.g. when printed on success/failure)
- [x] ~~Investigate whether or not step text expression matching may break due to capture groups not allowing token-ish strings (`{`, `}`, `.`, etc.) -- And if so, how to fix it.~~
  - This is probably a problem, but a brief perusal of steps indicates that it's not a huge problem at this time: most steps where you'd want to use a token use the generous `(.+)` to capture input.  It's unlikely you'd use a dynamic token for a field, for example.
- [x] Decide: should we maintain case in tokens
  - **Maintaining case** would look like: `{{salesforce.account.Id}}` or `{{web.googleAnalyticsRequest.cid}}`)
  - ~~**Lower-casing** tokens looks like: `{{salesforce.account.id}}` or `{{web.googleanalyticsrequest.cid}}`~~
-->